### PR TITLE
feat: Add Cursor IDE compatibility for OpenAI endpoint

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -138,7 +138,7 @@ export interface OpenAIToolCall {
 }
 
 /**
- * OpenAI Tool Definition
+ * OpenAI Tool Definition (standard format)
  */
 export interface OpenAITool {
   type: 'function';
@@ -151,6 +151,38 @@ export interface OpenAITool {
       required?: string[];
     };
   };
+}
+
+/**
+ * Flattened Tool Definition (used by Cursor IDE)
+ */
+export interface FlattenedTool {
+  type: 'function';
+  name: string;
+  description: string;
+  parameters: {
+    type: 'object';
+    properties: Record<string, any>;
+    required?: string[];
+  };
+}
+
+/**
+ * Union type for tool definitions (supports both formats)
+ */
+export type AnyOpenAITool = OpenAITool | FlattenedTool;
+
+/**
+ * Validation error with HTTP status code for proper client error responses
+ */
+export class ValidationError extends Error {
+  public readonly statusCode: number;
+
+  constructor(message: string, statusCode: number = 400) {
+    super(message);
+    this.name = 'ValidationError';
+    this.statusCode = statusCode;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
  - Support `input` field as alias for `messages` (Cursor uses non-standard field name)
  - Handle flattened tool format where name/description/parameters are at top level
  - Add validation for required fields with clear error messages

  ## Backwards Compatible
  Standard OpenAI clients continue to work - the non-standard handling only activates when standard fields are
  missing.

  ## Test Plan
  - [x] Tested with Cursor IDE
  - [x] Standard OpenAI format still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept the request "input" field as an alternative to "messages" for chat completions, increasing API flexibility
  * Broader tool-definition compatibility by supporting multiple tool format variations

* **Improvements**
  * Stronger runtime request and tool validation, requiring non-empty messages and model and validating tool metadata
  * Clearer error responses with explicit status codes for validation failures and improved error semantics

* **Chores**
  * Added structured types to support validation and error handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->