### PR TITLE
Fix: Prevent crash when error occurs during streaming response

### DIFF
--- a/src/router/middleware.ts
+++ b/src/router/middleware.ts
@@ -5,6 +5,37 @@ export const REQUIRED_SYSTEM_PROMPT: SystemMessage = {
   text: "You are Claude Code, Anthropic's official CLI for Claude.",
 };
 
+// List of valid top-level fields for Anthropic API requests
+const VALID_REQUEST_FIELDS = new Set([
+  'model',
+  'max_tokens',
+  'system',
+  'messages',
+  'tools',
+  'tool_choice',
+  'stream',
+  'temperature',
+  'top_p',
+  'top_k',
+  'stop_sequences',
+  'metadata',
+  'thinking',
+]);
+
+/**
+ * Strips unknown fields from the request to prevent API errors
+ * Fields like 'context_management' from the Agent SDK are not supported
+ */
+export function stripUnknownFields(request: Record<string, unknown>): AnthropicRequest {
+  const sanitized: Record<string, unknown> = {};
+  for (const key of Object.keys(request)) {
+    if (VALID_REQUEST_FIELDS.has(key)) {
+      sanitized[key] = request[key];
+    }
+  }
+  return sanitized as unknown as AnthropicRequest;
+}
+
 /**
  * Normalizes system prompt to SystemMessage[] format
  * Handles both string and array inputs

--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -295,6 +295,13 @@ const handleMessagesRequest = async (req: Request, res: Response) => {
       error instanceof Error ? error : new Error('Unknown error')
     );
 
+    // If headers were already sent (e.g., streaming response in progress),
+    // we cannot send an error response - just log and return
+    if (res.headersSent) {
+      logger.error(`[${requestId}] Error occurred after headers sent:`, error);
+      return;
+    }
+
     // Handle specific error cases
     if (error instanceof Error) {
       res.status(500).json({
@@ -443,6 +450,13 @@ const handleChatCompletionsRequest = async (req: Request, res: Response) => {
       error instanceof Error ? error : new Error('Unknown error'),
       'openai'
     );
+
+    // If headers were already sent (e.g., streaming response in progress),
+    // we cannot send an error response - just log and return
+    if (res.headersSent) {
+      logger.error(`[${requestId}] Error occurred after headers sent:`, error);
+      return;
+    }
 
     // Return OpenAI-format error
     const openaiError = translateAnthropicErrorToOpenAI(

--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -4,7 +4,7 @@ import express, { Request, Response } from 'express';
 import readline from 'readline';
 import { getValidAccessToken, loadTokens, saveTokens } from '../token-manager.js';
 import { startOAuthFlow, exchangeCodeForTokens } from '../oauth.js';
-import { ensureRequiredSystemPrompt } from './middleware.js';
+import { ensureRequiredSystemPrompt, stripUnknownFields } from './middleware.js';
 import { AnthropicRequest, AnthropicResponse, OpenAIChatCompletionRequest } from '../types.js';
 import { logger } from './logger.js';
 import {
@@ -222,8 +222,8 @@ const handleMessagesRequest = async (req: Request, res: Response) => {
   const timestamp = new Date().toISOString();
 
   try {
-    // Get the request body as an AnthropicRequest
-    const originalRequest = req.body as AnthropicRequest;
+    // Get the request body and strip unknown fields (e.g., context_management from Agent SDK)
+    const originalRequest = stripUnknownFields(req.body as Record<string, unknown>);
 
     const hadSystemPrompt = !!(originalRequest.system && originalRequest.system.length > 0);
 


### PR DESCRIPTION
## Problem

The router crashes with `ERR_HTTP_HEADERS_SENT` when an error occurs during a streaming response. This happens because:

1. A streaming request starts and headers are sent to the client
2. The `for await` loop begins writing chunks to the response
3. An error occurs mid-stream (e.g., connection drop, upstream timeout)
4. The catch block attempts to send a JSON error response
5. **Crash**: Headers were already sent, so `res.status(500).json()` fails

### Stack trace example:
```
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (node:_http_outgoing:642:11)
    at ServerResponse.header (.../express/lib/response.js:794:10)
    at handleMessagesRequest (.../server.ts:300:23)
```

## Solution

Check `res.headersSent` before attempting to send an error response in both handler functions:

- `handleMessagesRequest` (Anthropic `/v1/messages` endpoint)
- `handleChatCompletionsRequest` (OpenAI `/v1/chat/completions` endpoint)

```typescript
if (res.headersSent) {
  logger.error(`[${requestId}] Error occurred after headers sent:`, error);
  return;
}
```

This is the standard Express.js pattern for handling errors that occur after a streaming response has started.

## Impact

- **Before:** Router crashes and restarts, causing request failures and potential retry storms from clients
- **After:** Error is logged gracefully, connection closes cleanly, no crash

## Testing

1. Start the router
2. Send a streaming request
3. Simulate mid-stream error (e.g., kill upstream connection)
4. Verify router logs error but doesn't crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming message requests are now sanitized to ignore unexpected fields, improving request robustness.

* **Bug Fixes**
  * Improved error handling during streaming so duplicate/error responses are avoided when a response has already started.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->