### PR TITLE
Serve /v1/models endpoint without requiring an API key

### DIFF
--- a/src/router/models.ts
+++ b/src/router/models.ts
@@ -1,0 +1,65 @@
+/**
+ * Anthropic Models pulled from Anthropic API as of January 2026
+ * Source: https://api.anthropic.com/v1/models
+ */
+export const ANTHROPIC_MODELS = {
+  "data": [
+    {
+      "type": "model",
+      "id": "claude-opus-4-5-20251101",
+      "display_name": "Claude Opus 4.5",
+      "created_at": "2025-11-24T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-haiku-4-5-20251001",
+      "display_name": "Claude Haiku 4.5",
+      "created_at": "2025-10-15T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-sonnet-4-5-20250929",
+      "display_name": "Claude Sonnet 4.5",
+      "created_at": "2025-09-29T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-opus-4-1-20250805",
+      "display_name": "Claude Opus 4.1",
+      "created_at": "2025-08-05T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-opus-4-20250514",
+      "display_name": "Claude Opus 4",
+      "created_at": "2025-05-22T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-sonnet-4-20250514",
+      "display_name": "Claude Sonnet 4",
+      "created_at": "2025-05-22T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-3-7-sonnet-20250219",
+      "display_name": "Claude Sonnet 3.7",
+      "created_at": "2025-02-24T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-3-5-haiku-20241022",
+      "display_name": "Claude Haiku 3.5",
+      "created_at": "2024-10-22T00:00:00Z"
+    },
+    {
+      "type": "model",
+      "id": "claude-3-haiku-20240307",
+      "display_name": "Claude Haiku 3",
+      "created_at": "2024-03-07T00:00:00Z"
+    }
+  ],
+  "has_more": false,
+  "first_id": "claude-opus-4-5-20251101",
+  "last_id": "claude-3-haiku-20240307"
+};

--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -17,6 +17,7 @@ import {
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { ANTHROPIC_MODELS } from './models.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -173,7 +174,7 @@ app.get('/health', (_req: Request, res: Response) => {
   res.json({ status: 'ok', service: 'anthropic-max-plan-router' });
 });
 
-// OpenAI Models endpoint - proxy to Anthropic API with API key
+// OpenAI Models endpoint - proxy to Anthropic API with API key or return static list
 app.get('/v1/models', async (req: Request, res: Response) => {
   try {
     // Check for API key in headers
@@ -184,17 +185,12 @@ app.get('/v1/models', async (req: Request, res: Response) => {
         : null);
 
     if (!apiKey) {
-      res.status(401).json({
-        type: 'error',
-        error: {
-          type: 'authentication_error',
-          message:
-            'x-api-key header is required for /v1/models endpoint. Note: API key is only used for this endpoint; other endpoints use OAuth authentication.',
-        },
-      });
+      // No API key provided - return static model list
+      res.status(200).json(ANTHROPIC_MODELS);
       return;
     }
 
+    // API key provided - fetch live models from Anthropic API
     const response = await fetch('https://api.anthropic.com/v1/models', {
       method: 'GET',
       headers: {


### PR DESCRIPTION
If no API key is provided, it will serve a static list of models instead of fetching the models list from the Anthropic API. This makes the initial setup more streamlined as it doesn't require configuring 2 separate keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model information is now accessible without API authentication
  * Live model data from Anthropic is fetched when API credentials are provided

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->