### PR TITLE
Fix base URL in console output

### DIFF
--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -566,7 +566,7 @@ async function startRouter() {
       );
     } else {
       logger.startup(
-        '💡 Configure your AI tool to use http://localhost:' + PORT + ' as the base URL'
+        '💡 Configure your AI tool to use http://localhost:' + PORT + '/v1 as the base URL'
       );
     }
 


### PR DESCRIPTION
OpenAI tooling wants the `/v1` to be part of the base URL when you configure it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated startup guidance: Configuration instructions now specify the correct base URL format (http://localhost:<PORT>/v1) for the OpenAI endpoint, improving clarity during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->