### PR TITLE
Use port 45554 instead of 3000 by default

### DIFF
--- a/BEARER-TOKEN-PASSTHROUGH.md
+++ b/BEARER-TOKEN-PASSTHROUGH.md
@@ -49,7 +49,7 @@ npm run router
 
 Make a request with your Anthropic API key:
 ```bash
-curl -X POST http://localhost:3000/v1/messages \
+curl -X POST http://localhost:45554/v1/messages \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_ANTHROPIC_API_KEY" \
   -d '{
@@ -70,7 +70,7 @@ npm run router -- --disable-bearer-passthrough
 
 Make a request (even with bearer token):
 ```bash
-curl -X POST http://localhost:3000/v1/messages \
+curl -X POST http://localhost:45554/v1/messages \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ANY_TOKEN_HERE" \
   -d '{
@@ -86,7 +86,7 @@ curl -X POST http://localhost:3000/v1/messages \
 
 Works with OpenAI-compatible endpoint too:
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_ANTHROPIC_API_KEY" \
   -d '{

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm start
 ```
 
 ### 🚀 **2. API Router** - Production Ready
-A standalone HTTP proxy with **both Anthropic and OpenAI endpoints** that lets ANY AI tool use your MAX Plan subscription via `http://localhost:3000`.
+A standalone HTTP proxy with **both Anthropic and OpenAI endpoints** that lets ANY AI tool use your MAX Plan subscription via `http://localhost:45554`.
 
 **Works with:** Anthropic SDK, OpenAI SDK, LangChain, LiteLLM, and any tool that supports custom base URLs!
 
@@ -104,7 +104,7 @@ npx anthropic-max-router
 
 That's it! The router will:
 1. Automatically authenticate you via OAuth (first run only)
-2. Start the proxy server on http://localhost:3000 with **both Anthropic and OpenAI endpoints**
+2. Start the proxy server on http://localhost:45554 with **both Anthropic and OpenAI endpoints**
 3. Let you use MAX Plan billing from **any tool** - whether it uses Anthropic or OpenAI format!
 
 ### With Options
@@ -207,7 +207,7 @@ A standalone HTTP proxy server with **dual API endpoints** (Anthropic + OpenAI) 
 - `/v1/messages` - Native Anthropic Messages API
 - `/v1/chat/completions` - OpenAI Chat Completions API (auto-translates to Anthropic)
 
-Works with tools built for either Anthropic or OpenAI - just point them to `http://localhost:3000`!
+Works with tools built for either Anthropic or OpenAI - just point them to `http://localhost:45554`!
 
 ### How It Works
 
@@ -216,7 +216,7 @@ Works with tools built for either Anthropic or OpenAI - just point them to `http
 │   Your AI Tool      │
 │   (any application) │
 └──────────┬──────────┘
-           │ http://localhost:3000
+           │ http://localhost:45554
            ▼
 ┌─────────────────────────────────────┐
 │  Router (This Application)          │
@@ -247,7 +247,7 @@ Works with tools built for either Anthropic or OpenAI - just point them to `http
 ### Basic Usage
 
 ```bash
-# Start router (default: port 3000, medium verbosity)
+# Start router (default: port 45554, medium verbosity)
 npm run router
 
 # With options
@@ -268,7 +268,7 @@ npm run router -- -p 8080 --verbose        # Combine options
 |--------|-------|-------------|
 | `--help` | `-h` | Show help message |
 | `--version` | `-v` | Show version number |
-| `--port PORT` | `-p` | Set port (default: 3000) |
+| `--port PORT` | `-p` | Set port (default: 45554) |
 | **Endpoint Control** | | |
 | `--enable-anthropic` | | Enable Anthropic /v1/messages endpoint (default: enabled) |
 | `--disable-anthropic` | | Disable Anthropic endpoint |
@@ -343,7 +343,7 @@ The router exposes **both Anthropic and OpenAI endpoints** by default:
 Native Anthropic format. Use with Anthropic SDK or any Anthropic-compatible tool.
 
 ```bash
-curl -X POST http://localhost:3000/v1/messages \
+curl -X POST http://localhost:45554/v1/messages \
   -H "Content-Type: application/json" \
   -d '{"model":"claude-sonnet-4-5","max_tokens":100,"messages":[{"role":"user","content":"Hello"}]}'
 ```
@@ -352,7 +352,7 @@ curl -X POST http://localhost:3000/v1/messages \
 OpenAI-compatible format with automatic translation to Anthropic. Use with OpenAI SDK, LangChain, LiteLLM, etc.
 
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}'
 ```
@@ -363,7 +363,7 @@ Returns a list of available Claude models from Anthropic.
 **⚠️ Important:** This endpoint requires an Anthropic API key (not OAuth). The API key is **only used for this endpoint** - all other endpoints use OAuth authentication.
 
 ```bash
-curl http://localhost:3000/v1/models \
+curl http://localhost:45554/v1/models \
   -H "x-api-key: sk-ant-api03-..."
 ```
 
@@ -382,7 +382,7 @@ curl http://localhost:3000/v1/models \
 
 #### **`GET /health`** - Health check
 ```bash
-curl http://localhost:3000/health
+curl http://localhost:45554/health
 # Returns: {"status":"ok","service":"anthropic-max-plan-router"}
 ```
 
@@ -394,13 +394,13 @@ The router supports the OpenAI Chat Completions API format, enabling **zero-code
 
 | What You Have | What You Get | How |
 |---------------|--------------|-----|
-| Tool built for Anthropic | Use native Anthropic endpoint | Point to `http://localhost:3000` |
-| Tool built for OpenAI | Use OpenAI-compatible endpoint | Point to `http://localhost:3000` |
+| Tool built for Anthropic | Use native Anthropic endpoint | Point to `http://localhost:45554` |
+| Tool built for OpenAI | Use OpenAI-compatible endpoint | Point to `http://localhost:45554` |
 | Both types of tools | Use both simultaneously! | Both endpoints work at the same time |
 
 #### Why OpenAI Compatibility?
 
-Many AI tools and libraries (Python OpenAI SDK, LangChain, etc.) are built exclusively for OpenAI's API format. With the OpenAI-compatible endpoint, these tools can use your MAX Plan subscription without any code changes - just point them to `http://localhost:3000`.
+Many AI tools and libraries (Python OpenAI SDK, LangChain, etc.) are built exclusively for OpenAI's API format. With the OpenAI-compatible endpoint, these tools can use your MAX Plan subscription without any code changes - just point them to `http://localhost:45554`.
 
 #### Using OpenAI Compatibility
 
@@ -497,7 +497,7 @@ from openai import OpenAI
 
 client = OpenAI(
     api_key="not-used",  # Can be anything - router handles auth
-    base_url="http://localhost:3000/v1",  # Note: include /v1
+    base_url="http://localhost:45554/v1",  # Note: include /v1
 )
 
 response = client.chat.completions.create(
@@ -517,7 +517,7 @@ import OpenAI from 'openai';
 
 const client = new OpenAI({
   apiKey: 'not-used',  // Can be anything - router handles auth
-  baseURL: 'http://localhost:3000/v1',  // Note: include /v1
+  baseURL: 'http://localhost:45554/v1',  // Note: include /v1
 });
 
 const response = await client.chat.completions.create({
@@ -533,7 +533,7 @@ console.log(response.choices[0].message.content);
 
 **cURL:**
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "gpt-4",
@@ -553,7 +553,7 @@ from openai import OpenAI
 
 client = OpenAI(
     api_key="not-used",
-    base_url="http://localhost:3000/v1",
+    base_url="http://localhost:45554/v1",
 )
 
 stream = client.chat.completions.create(
@@ -604,14 +604,14 @@ Send a test request:
 
 **PowerShell:**
 ```powershell
-curl -X POST http://localhost:3000/v1/messages `
+curl -X POST http://localhost:45554/v1/messages `
   -H "Content-Type: application/json" `
   -d '{"model":"claude-sonnet-4-5","max_tokens":50,"messages":[{"role":"user","content":"Say hello in one short sentence."}]}'
 ```
 
 **Bash/Linux/Mac:**
 ```bash
-curl -X POST http://localhost:3000/v1/messages \
+curl -X POST http://localhost:45554/v1/messages \
   -H "Content-Type: application/json" \
   -d '{
     "model": "claude-sonnet-4-5",
@@ -628,7 +628,7 @@ You should see the request logged in your router terminal and get a JSON respons
 
 Configure any AI tool that supports custom base URLs to point to:
 ```
-http://localhost:3000
+http://localhost:45554
 ```
 
 > **🔑 Important Note About API Keys**
@@ -640,7 +640,7 @@ http://localhost:3000
 **JavaScript/TypeScript:**
 ```javascript
 const client = new AnthropicClient({
-  baseURL: 'http://localhost:3000',
+  baseURL: 'http://localhost:45554',
   // No API key needed - router handles authentication
 });
 ```
@@ -651,7 +651,7 @@ import anthropic
 
 client = anthropic.Anthropic(
     api_key="not-used",  # Can be anything - router handles auth
-    base_url="http://localhost:3000",
+    base_url="http://localhost:45554",
 )
 
 response = client.messages.create(

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,8 +13,8 @@ npm run router -- --enable-openai --verbose
 The startup should show:
 ```
 📋 Endpoints:
-   POST http://localhost:3000/v1/chat/completions (OpenAI)
-   GET  http://localhost:3000/health
+   POST http://localhost:45554/v1/chat/completions (OpenAI)
+   GET  http://localhost:45554/health
 ```
 
 ### 2. Run Automated Tests (Node.js)
@@ -67,7 +67,7 @@ This tests real-world compatibility with the official OpenAI SDK, including:
 
 **PowerShell:**
 ```powershell
-curl -X POST http://localhost:3000/v1/chat/completions `
+curl -X POST http://localhost:45554/v1/chat/completions `
   -H "Content-Type: application/json" `
   -d '{
     "model": "claude-opus-4-5",
@@ -81,7 +81,7 @@ curl -X POST http://localhost:3000/v1/chat/completions `
 
 **Bash/Linux/Mac:**
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "claude-opus-4-5",
@@ -105,12 +105,12 @@ Run with different models and check router logs:
 
 ```bash
 # Test claude-opus-4-5 → claude-opus-4-5
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-5", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 10}'
 
 # Test claude-opus-4-5 → claude-haiku-4-5
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-5", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 10}'
 ```
@@ -122,7 +122,7 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 ### Test 3: Streaming
 
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -N \
   -d '{
@@ -142,7 +142,7 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 
 Test unsupported parameter `n > 1`:
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "claude-opus-4-5",
@@ -166,12 +166,12 @@ npm run router -- --enable-all-endpoints --verbose
 Send requests to both:
 ```bash
 # OpenAI endpoint
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-5", "messages": [{"role": "user", "content": "Hi from OpenAI"}], "max_tokens": 20}'
 
 # Anthropic endpoint
-curl -X POST http://localhost:3000/v1/messages \
+curl -X POST http://localhost:45554/v1/messages \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-5", "messages": [{"role": "user", "content": "Hi from Anthropic"}], "max_tokens": 20}'
 ```
@@ -197,7 +197,7 @@ import OpenAI from 'openai';
 
 const client = new OpenAI({
   apiKey: 'not-used',
-  baseURL: 'http://localhost:3000/v1',
+  baseURL: 'http://localhost:45554/v1',
 });
 
 async function test() {
@@ -249,7 +249,7 @@ ANTHROPIC_DEFAULT_MODEL=claude-haiku-4-5 npm run router -- --enable-openai --ver
 
 Send a request:
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "claude-opus-4-5", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 10}'
 ```
@@ -273,7 +273,7 @@ npm run router -- --enable-openai --verbose
 
 Test:
 ```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
+curl -X POST http://localhost:45554/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "my-custom-model", "messages": [{"role": "user", "content": "Hi"}], "max_tokens": 10}'
 ```
@@ -333,7 +333,7 @@ from langchain_openai import ChatOpenAI
 llm = ChatOpenAI(
     model="claude-opus-4-5",
     api_key="not-used",
-    base_url="http://localhost:3000/v1"
+    base_url="http://localhost:45554/v1"
 )
 
 response = llm.invoke("Say hello!")
@@ -348,7 +348,7 @@ import litellm
 response = litellm.completion(
     model="claude-opus-4-5",
     messages=[{"role": "user", "content": "Hello!"}],
-    api_base="http://localhost:3000/v1",
+    api_base="http://localhost:45554/v1",
     api_key="not-used"
 )
 
@@ -369,7 +369,7 @@ print(response.choices[0].message.content)
 
 ### Connection refused
 - Check: Router is running on correct port
-- Solution: Verify with `curl http://localhost:3000/health`
+- Solution: Verify with `curl http://localhost:45554/health`
 
 ### Model mapping not working
 - Check: Router logs in verbose mode

--- a/examples/test-router.js
+++ b/examples/test-router.js
@@ -6,7 +6,7 @@
  */
 
 async function testRouter() {
-  const ROUTER_URL = 'http://localhost:3000';
+  const ROUTER_URL = 'http://localhost:45554';
 
   // Test 1: Health check
   console.log('Testing health endpoint...');

--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -118,7 +118,7 @@ Usage: npm run router [options]
 Options:
   -h, --help                Show this help message
   -v, --version             Show version number
-  -p, --port PORT           Port to listen on (default: 3000)
+  -p, --port PORT           Port to listen on (default: 45554)
 
   Endpoint control (default: both enabled):
   --enable-anthropic        Enable Anthropic /v1/messages endpoint (default: enabled)
@@ -137,7 +137,7 @@ Options:
   -V, --verbose             Maximum logging - full request/response bodies
 
 Environment variables:
-  ROUTER_PORT               Port to listen on (default: 3000)
+  ROUTER_PORT               Port to listen on (default: 45554)
   ANTHROPIC_DEFAULT_MODEL   Override model mapping (e.g., claude-haiku-4-5)
 
 Examples:
@@ -154,7 +154,7 @@ More info: https://github.com/nsxdavid/anthropic-max-router
 `);
 }
 
-let PORT = process.env.ROUTER_PORT ? parseInt(process.env.ROUTER_PORT) : 3000;
+let PORT = process.env.ROUTER_PORT ? parseInt(process.env.ROUTER_PORT) : 45554;
 parseArgs();
 
 const app = express();

--- a/tests/test-openai-endpoint.js
+++ b/tests/test-openai-endpoint.js
@@ -17,7 +17,7 @@
  *      node test-openai-endpoint.js
  */
 
-const BASE_URL = 'http://localhost:3000';
+const BASE_URL = 'http://localhost:45554';
 
 // ANSI color codes for pretty output
 const colors = {
@@ -333,7 +333,7 @@ async function runAllTests() {
   log('Prerequisites:', 'yellow');
   log('  1. Router must be running with: npm run router -- --enable-openai', 'yellow');
   log('  2. OAuth authentication must be completed', 'yellow');
-  log('  3. Router should be on http://localhost:3000\n', 'yellow');
+  log('  3. Router should be on http://localhost:45554\n', 'yellow');
 
   const results = {
     passed: 0,

--- a/tests/test-openai-sdk.py
+++ b/tests/test-openai-sdk.py
@@ -48,7 +48,7 @@ def test1_basic_completion():
     try:
         client = OpenAI(
             api_key="not-used",  # Router handles auth
-            base_url="http://localhost:3000/v1",
+            base_url="http://localhost:45554/v1",
         )
 
         response = client.chat.completions.create(
@@ -80,7 +80,7 @@ def test2_streaming():
     try:
         client = OpenAI(
             api_key="not-used",
-            base_url="http://localhost:3000/v1",
+            base_url="http://localhost:45554/v1",
         )
 
         log('✅ Starting stream...', 'GREEN')
@@ -121,7 +121,7 @@ def test3_multiple_models():
         try:
             client = OpenAI(
                 api_key="not-used",
-                base_url="http://localhost:3000/v1",
+                base_url="http://localhost:45554/v1",
             )
 
             response = client.chat.completions.create(
@@ -147,7 +147,7 @@ def test4_system_messages():
     try:
         client = OpenAI(
             api_key="not-used",
-            base_url="http://localhost:3000/v1",
+            base_url="http://localhost:45554/v1",
         )
 
         response = client.chat.completions.create(
@@ -177,7 +177,7 @@ def test5_error_handling():
     try:
         client = OpenAI(
             api_key="not-used",
-            base_url="http://localhost:3000/v1",
+            base_url="http://localhost:45554/v1",
         )
 
         response = client.chat.completions.create(
@@ -206,7 +206,7 @@ def run_all_tests():
     log('Prerequisites:', 'YELLOW')
     log('  1. Router running with: npm run router -- --enable-openai', 'YELLOW')
     log('  2. OpenAI SDK installed: pip install openai', 'YELLOW')
-    log('  3. Router on http://localhost:3000\n', 'YELLOW')
+    log('  3. Router on http://localhost:45554\n', 'YELLOW')
 
     results = {'passed': 0, 'failed': 0}
 


### PR DESCRIPTION
Port 3000 is a very common port number that is likely to conflict with other things on a user's system.

It's nice to use a unique port number by default. For example, ollama uses 11434 (leet-speak for "llama"). I based 45554 on the fact Claude Code uses 45454 for its OAuth server.