### PR TITLE
Draft: Fix initial prompt to configure tokens

### DIFF
--- a/src/router/server.ts
+++ b/src/router/server.ts
@@ -496,10 +496,16 @@ async function startRouter() {
   // Check if we have tokens
   let tokens = await loadTokens();
 
-  if (!tokens && !endpointConfig.allowBearerPassthrough) {
-    // OAuth is required when bearer passthrough is disabled
+  if (!tokens) {
+    // No OAuth tokens found - prompt user for authentication
     logger.startup('No OAuth tokens found. Starting authentication...');
     logger.startup('');
+    
+    if (endpointConfig.allowBearerPassthrough) {
+      logger.startup('💡 Note: You can skip OAuth and use bearer token passthrough instead.');
+      logger.startup('   Press Ctrl+C to cancel, or continue with OAuth setup.');
+      logger.startup('');
+    }
 
     try {
       const { code, verifier, state } = await startOAuthFlow(askQuestion);
@@ -521,7 +527,7 @@ async function startRouter() {
     logger.startup('✅ OAuth tokens found.');
   }
 
-  // Validate/refresh token (skip if no tokens and passthrough is enabled)
+  // Validate/refresh token
   if (tokens) {
     try {
       await getValidAccessToken();
@@ -532,8 +538,6 @@ async function startRouter() {
       rl.close();
       process.exit(1);
     }
-  } else if (endpointConfig.allowBearerPassthrough) {
-    logger.startup('⚠️  No OAuth tokens - bearer passthrough mode only');
   }
 
   // Close readline interface since we don't need it anymore


### PR DESCRIPTION
Fixes #4 

It seems like the "passthrough" feature prevents the token prompt from being displayed. This makes the token prompt be displayed again, but I am not sure how to make "passthrough" work.

Personally if it was me, I would remove passthrough mode because I don't think it's useful. It's far more useful to use your Claude Pro account with an OpenAI-compatible tool. I would even remove the Anthropic endpoint as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined authentication flow initialization for clearer logic.
  * Added helpful guidance when authentication tokens are unavailable, including bearer passthrough information.
  * Improved token validation and messaging experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->